### PR TITLE
add `replace` `only` and `except` plugin

### DIFF
--- a/src/plugins.json
+++ b/src/plugins.json
@@ -142,5 +142,23 @@
     "icon": "files",
     "repository": "https://github.com/christophercliff/metalsmith-webpack",
     "description": "Bundle CommonJS, AMD and ES6 modules."
+  },
+  {
+    "name": "Replace",
+    "icon": "files",
+    "repository": "https://github.com/Jeremial/metalsmith-replace",
+    "description": "An attribute's value replace plugin for metalsmith."
+  },
+  {
+    "name": "Except",
+    "icon": "files",
+    "repository": "https://github.com/Jeremial/metalsmith-except",
+    "description": "A file's attribute except filter for metalsmith."
+  },
+  {
+    "name": "Only",
+    "icon": "files",
+    "repository": "https://github.com/Jeremial/metalsmith-only",
+    "description": "A file's attribute only filter for metalsmith."
   }
 ]


### PR DESCRIPTION
the `metalsmith-replace` can be used to replace string in files' attribute value.

the `metalsmith-only` and `metalsmith-except` can be used to filter files' attribute. 

`metalsmith-only` can filter out the attribute which match the option, and other attributes will be deleted from files.

`metalsmith-except` can filter out the attribute which match the option, and then they will be deleted from files
