### PR TITLE
add metalsmith-assets to plugins list

### DIFF
--- a/src/plugins.json
+++ b/src/plugins.json
@@ -6,6 +6,12 @@
     "description": "Automatically add vendor prefixes to CSS."
   },
   {
+    "name": "Assets",
+    "icon": "addfile",
+    "repository": "https://github.com/treygriffith/metalsmith-assets",
+    "description": "Include static assets in your build."
+  },
+  {
     "name": "Branch",
     "icon": "fork",
     "repository": "https://github.com/ericgj/metalsmith-branch",


### PR DESCRIPTION
Metalsmith-assets brings files from a different directory into the files list, used for things like copying static assets into the build directory.
