### PR TITLE
Add contentful plugin to the list

### DIFF
--- a/src/plugins.json
+++ b/src/plugins.json
@@ -262,5 +262,11 @@
     "icon": "files",
     "repository": "https://github.com/christophercliff/metalsmith-webpack",
     "description": "Bundle CommonJS, AMD and ES6 modules."
+  },
+  {
+    "name": "Contentful",
+    "icon": "layergroup",
+    "repository": "https://github.com/contentful/contentful-metalsmith",
+    "description": "Create static sites with data stored at Contentful.com"
   }
 ]


### PR DESCRIPTION
Hi,

We have developed a plugin for Metalsmith to generate static sites with data stored and served by [Contentful](www.contenful.com).

Please review it and share your thoughts and if you find it interesting we'd love to see it on the plugin list.
