### PR TITLE
Add Mtime plugin

### DIFF
--- a/build/index.html
+++ b/build/index.html
@@ -388,6 +388,14 @@ An unfinished article...
   </li>
 
   <li class="Plugin">
+    <a class="Plugin-link" href="https://github.com/jkuczm/metalsmith-mtime">
+      <h1 class="Plugin-title">Mtime<i class="Plugin-icon ss-clock"></i></h1>
+      <i class="Plugin-arrow ss-right"></i>
+      <p class="Plugin-description">Add files last modification times to their metadata.</p>
+    </a>
+  </li>
+
+  <li class="Plugin">
     <a class="Plugin-link" href="https://github.com/skinkworks/metalsmith-jade">
       <h1 class="Plugin-title">Jade<i class="Plugin-icon ss-compose"></i></h1>
       <i class="Plugin-arrow ss-right"></i>

--- a/src/plugins.json
+++ b/src/plugins.json
@@ -156,6 +156,12 @@
     "description": "Convert Markdown files to HTML."
   },
   {
+    "name": "Mtime",
+    "icon": "clock",
+    "repository": "https://github.com/jkuczm/metalsmith-mtime",
+    "description": "Add files last modification times to their metadata."
+  },
+  {
     "name": "Jade",
     "icon": "compose",
     "repository": "https://github.com/skinkworks/metalsmith-jade",


### PR DESCRIPTION
This plugin adds last modification time of each file to its metadata.

I thought that, since to get proper file mtimes from git one needs some [additional tools](https://git.wiki.kernel.org/index.php/InterfacesFrontendsAndTools#Backups.2C_metadata.2C_and_large_files), this plugin won't be of much use to anyone except me. But because there are already [some downloads](http://npm-stat.com/charts.html?package=metalsmith-mtime), maybe others also find it useful.
