### PR TITLE
Add Lunr.js plugin.

### DIFF
--- a/src/plugins.json
+++ b/src/plugins.json
@@ -168,6 +168,12 @@
     "description": "Convert LESS files to CSS."
   },
   {
+    "name": "Lunr Search",
+    "icon": "search",
+    "repository": "https://github.com/CMClay/metalsmith-lunr",
+    "description": "Implement Lunr.js client-side search engine."
+  },
+  {
     "name": "Markdown",
     "icon": "compose",
     "repository": "https://github.com/segmentio/metalsmith-markdown",


### PR DESCRIPTION
A plugin that generates a JSON index based on Metalsmith metadata that can be loaded by the Lunr.js client-side search engine. Hope you like!

https://github.com/CMClay/metalsmith-lunr
