### PR TITLE
Add prismic plugin

### DIFF
--- a/src/plugins.json
+++ b/src/plugins.json
@@ -216,6 +216,12 @@
     "description": "Apply custom permalinks and rename files to be nested properly for static sites, basically converting `about.html` into `about/index.html`."
   },
   {
+    "name": "Prismic",
+    "icon": "layergroup",
+    "repository": "https://github.com/mbanting/metalsmith-prismic",
+    "description": "Create static sites with data stored at Prismic.io"
+  },  
+  {
     "name": "Prompt",
     "icon": "chat",
     "repository": "https://github.com/segmentio/metalsmith-prompt",


### PR DESCRIPTION
A plugin that pulls in data from your [prismic.io](https://prismic.io/) content repository for use/display in your Metalsmith.io static site. 

https://github.com/mbanting/metalsmith-prismic
