### PR TITLE
add metalsmith-metadata-directory to plugins list

### DIFF
--- a/src/plugins.json
+++ b/src/plugins.json
@@ -613,6 +613,12 @@
     "description": "Load metadata from JSON or YAML files."
   },
   {
+    "name": "Metadata Directory",
+    "icon": "tag",
+    "repository": "https://github.com/fephil/metalsmith-metadata-directory",
+    "description": "Add a directory of JSON files for use in templates and pages."
+  },
+  {
     "name": "Metafiles",
     "icon": "files",
     "repository": "https://github.com/Ajedi32/metalsmith-metafiles",


### PR DESCRIPTION
Hi, I have just released version 1.0.0 of my plugin with unit testing so thought it would be a good time to add it to the directory. I believe it's different enough to the existing metadata plugin to warrant its inclusion.

Thanks.

EDIT: Link to repo: https://github.com/fephil/metalsmith-metadata-directory/

