### PR TITLE
Use path to resolve file locations (#206)

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,10 +1,12 @@
 'use strict';
 
 module.exports = (grunt) => {
+  const path = require('path');
+
   grunt.initConfig({
     shell: {
       componentinstall: {
-        command: './node_modules/.bin/component install'
+        command: path.resolve(`${ process.cwd() }/node_modules/.bin/component install`)
       }
     },
     clean: {
@@ -81,7 +83,7 @@ module.exports = (grunt) => {
     }));
     m.use(layouts({
       engine: 'swig',
-      directory: './'
+      directory: process.cwd()
     }));
     m.build((err) => {
       if (err) {


### PR DESCRIPTION
Tested on Windows 7, with native cmd line and [cmder](https://github.com/cmderdev/cmder), using latest node LTS (4.6.0). I unfortunately don't have a Win 10 vm running yet but I don't expect any issues on that platform (famous last words?). 

`build`, `start` (connect), and `test` scripts all run successfully. 