### PR TITLE
add metalsmith-github-markdown plugin

### DIFF
--- a/src/plugins.json
+++ b/src/plugins.json
@@ -373,6 +373,12 @@
     "description": "Lets you get gists from Github Gist"
   },
   {
+    "name": "GitHub Markdown",
+    "icon": "compose",
+    "repository": "https://github.com/cusxio/metalsmith-github-markdown",
+    "description": "Convert markdown with Github Markdown API."
+  },
+  {
     "name": "Google Analytics",
     "icon": "write",
     "repository": "https://github.com/doodzik/metalsmith-google-analytics",


### PR DESCRIPTION
Metalsmith Plugin to convert markdown with GitHub Markdown API.