### PR TITLE
Add Atomizer plugin

### DIFF
--- a/src/plugins.json
+++ b/src/plugins.json
@@ -24,6 +24,12 @@
     "description": "Include static assets in your build."
   },
   {
+    "name": "Atomizer",
+    "icon": "addfile",
+    "repository": "https://github.com/tests-always-included/metalsmith-atomizer",
+    "description": "Automatically generate Atomic CSS from HTML using Atomizer."
+  },
+  {
     "name": "Author",
     "icon": "users",
     "repository": "https://github.com/almirfilho/metalsmith-author",


### PR DESCRIPTION
Based on work from gulp-atomizer, this uses Yahoo's CSS generation tool, Atomizer, to build a CSS file automatically from HTML.  Developers only need to edit HTML and this creates less delicate HTML and significantly smaller CSS.  It's a blessing for any site maintenance.