### PR TITLE
Adding data loader plugin

### DIFF
--- a/src/plugins.json
+++ b/src/plugins.json
@@ -186,6 +186,12 @@
     "description": "Add creation and updated timestamps"
   },
   {
+     "name": "Data Loader",
+     "icon": "tag",
+     "repository": "https://github.com/tests-always-included/metalsmith-data-loader",
+     "description": "Load JSON/YAML files into the metadata of files from within your source tree or a models folder."
+  },
+  {
      "name": "Data Markdown",
      "icon": "gridlines",
      "repository": "https://github.com/majodev/metalsmith-data-markdown",


### PR DESCRIPTION
I'm proposing the addition of the [metalsmith-data-loader] plugin.  It is very close to [metalsmith-models].  To be up front and honest, I did not contact the developer of the models plugin to add extra functionality for the following reasons:

1. The repository has not seen a commit in the last 9 months.
2. There's a fatal flaw in the program already when no files use any models.  There's also a pull request since Nov 8 to fix it.
3. No tests exist in the models repository.
4. The amount of changes necessary was pretty invasive and would likely be breaking.

So, I'd understand completely if this pull request was not acceptable to be merged.

[metalsmith-models]: https://github.com/jaichandra/metalsmith-models
[metalsmith-data-loader]: https://github.com/tests-always-included/metalsmith-data-loader