### PR TITLE
Added metalsmith-asciidoctor plugin to list

### DIFF
--- a/src/plugins.json
+++ b/src/plugins.json
@@ -30,6 +30,12 @@
     "description": "Create an archives page organized by date fields."
   },
   {
+    "name": "Asciidoctor",
+    "icon": "files",
+    "repository": "https://github.com/chkal/metalsmith-asciidoctor",
+    "description": "Plugin to transform AsciiDoc files to HTML using asciidoctor.js"
+  },
+  {
     "name": "Assert",
     "icon": "addfile",
     "repository": "https://github.com/MorganConrad/metalsmith-assert",


### PR DESCRIPTION
This pull requests adds [metalsmith-asciidoctor](https://github.com/chkal/metalsmith-asciidoctor) to the list of plugins. This plugin allows to transform AsciiDoc files to HTML using [asciidoctor.js](http://asciidoctor.org/docs/asciidoctor.js/).

Please let me know if you need more infos.