### PR TITLE
feat(plugins): add several badges to plugin view

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -68,16 +68,14 @@ module.exports = (grunt) => {
 
     let done = this.async();
 
-    const githubRegex = /github\.com\/([^\/]+)\/([^/]+)\/?$/;
+    const githubRegex = /github\.com\/([^/]+)\/([^/]+)\/?$/;
     const oneWeek = 7 * 24 * 60 * 60;
 
-    const m = Metalsmith(__dirname);
     const plugins = require('./src/plugins.json')
       .map((plugin) => {
         const result = githubRegex.exec(plugin.repository);
         if (result) {
-          const user = result[1];
-          const repo = result[2];
+          const [, user, repo] = result;
           const npm = plugin.npm || repo;
           Object.assign(plugin, {
             respositoryIssues: `${plugin.repository}/issues`,
@@ -92,6 +90,8 @@ module.exports = (grunt) => {
         }
         return plugin;
       });
+
+    const m = Metalsmith(__dirname);
     m.metadata({
       placeholderBadgeUrl: 'https://img.shields.io/badge/badge-loading-lightgrey.svg?style=flat',
       plugins,

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -83,9 +83,9 @@ module.exports = (grunt) => {
             npmDownloads: `https://img.shields.io/npm/dy/${repo}.svg?maxAge=${oneWeek}`,
             npmVersion: `https://img.shields.io/npm/v/${repo}.svg?maxAge=${oneWeek}`,
             githubStars: `https://img.shields.io/github/stars/${user}/${repo}.svg?maxAge=${oneWeek}`,
-            githubIssues: `https://img.shields.io/github/issues/${user}/${repo}.svg?maxAge=${oneWeek}`,
             bithoundUrl: `https://www.bithound.io/github/${user}/${repo}`,
-            bithoundStatus: `https://www.bithound.io/github/${user}/${repo}/badges/code.svg`
+            bithoundScore: `https://www.bithound.io/github/${user}/${repo}/badges/score.svg`,
+            bithoundDependencies: `https://www.bithound.io/github/${user}/${repo}/badges/dependencies.svg`
           });
         }
         return plugin;

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -68,20 +68,22 @@ module.exports = (grunt) => {
 
     let done = this.async();
 
+    const githubRegex = /github\.com\/([^\/]+)\/([^/]+)\/?$/;
+    const oneWeek = 7 * 24 * 60 * 60;
+
     const m = Metalsmith(__dirname);
     const plugins = require('./src/plugins.json')
       .map((plugin) => {
-        const githubRegex = /github\.com\/([^\/]+)\/([^/]+)\/?$/;
         const result = githubRegex.exec(plugin.repository);
         if (result) {
           const user = result[1];
           const repo = result[2];
-          const oneWeek = 7 * 24 * 60 * 60;
+          const npm = plugin.npm || repo;
           Object.assign(plugin, {
             respositoryIssues: `${plugin.repository}/issues`,
-            npmUrl: `https://www.npmjs.com/package/${repo}`,
-            npmDownloads: `https://img.shields.io/npm/dy/${repo}.svg?maxAge=${oneWeek}`,
-            npmVersion: `https://img.shields.io/npm/v/${repo}.svg?maxAge=${oneWeek}`,
+            npmUrl: `https://www.npmjs.com/package/${npm}`,
+            npmDownloads: `https://img.shields.io/npm/dy/${npm}.svg?maxAge=${oneWeek}`,
+            npmVersion: `https://img.shields.io/npm/v/${npm}.svg?maxAge=${oneWeek}`,
             githubStars: `https://img.shields.io/github/stars/${user}/${repo}.svg?maxAge=${oneWeek}`,
             bithoundUrl: `https://www.bithound.io/github/${user}/${repo}`,
             bithoundScore: `https://www.bithound.io/github/${user}/${repo}/badges/score.svg`,

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -69,11 +69,33 @@ module.exports = (grunt) => {
     let done = this.async();
 
     const m = Metalsmith(__dirname);
+    const plugins = require('./src/plugins.json')
+      .map((plugin) => {
+        const githubRegex = /github\.com\/([^\/]+)\/([^/]+)\/?$/;
+        const result = githubRegex.exec(plugin.repository);
+        if (result) {
+          const user = result[1];
+          const repo = result[2];
+          const oneWeek = 7 * 24 * 60 * 60;
+          Object.assign(plugin, {
+            respositoryIssues: `${plugin.repository}/issues`,
+            npmUrl: `https://www.npmjs.com/package/${repo}`,
+            npmDownloads: `https://img.shields.io/npm/dy/${repo}.svg?maxAge=${oneWeek}`,
+            npmVersion: `https://img.shields.io/npm/v/${repo}.svg?maxAge=${oneWeek}`,
+            githubStars: `https://img.shields.io/github/stars/${user}/${repo}.svg?maxAge=${oneWeek}`,
+            githubIssues: `https://img.shields.io/github/issues/${user}/${repo}.svg?maxAge=${oneWeek}`,
+            bithoundUrl: `https://www.bithound.io/github/${user}/${repo}`,
+            bithoundStatus: `https://www.bithound.io/github/${user}/${repo}/badges/code.svg`
+          });
+        }
+        return plugin;
+      });
     m.metadata({
+      placeholderBadgeUrl: 'https://img.shields.io/badge/badge-loading-lightgrey.svg?style=flat',
+      plugins,
       nodeVersion
     });
     m.use(metadata({
-      plugins: 'plugins.json',
       examples: 'examples.json'
     }));
     m.use(inPlace({

--- a/component.json
+++ b/component.json
@@ -1,7 +1,10 @@
 {
   "name": "metalsmith.io",
   "private": true,
-  "scripts": ["index.js"],
+  "scripts": [
+    "node_modules/blazy/blazy.min.js",
+    "index.js"
+  ],
   "styles": ["index.css"],
   "images": [
     "images/favicon.png",

--- a/index.css
+++ b/index.css
@@ -305,6 +305,13 @@ hr:nth-of-type(14) {
   display: block;
 }
 
+.Plugin-badges {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  margin-top: 1em;
+}
+
 /**
  * Header.
  */

--- a/index.css
+++ b/index.css
@@ -256,12 +256,12 @@ hr:nth-of-type(14) {
  */
 .Plugin-list {
   max-height: 70vh;
-  overflow: scroll;
+  overflow-y: scroll;
 }
 
 .Plugin {
   position: relative;
-  padding: 1.5em;
+  padding: 1.25em;
   background-color: white;
 }
 
@@ -457,14 +457,6 @@ hr:nth-of-type(14) {
 
   .Example:nth-child(2n) {
     margin-top: 1px;
-  }
-
-  /**
-   * Plugin.
-   */
-
-  .Plugin {
-    padding: 1.5em 2em;
   }
 
   /**

--- a/index.css
+++ b/index.css
@@ -309,6 +309,9 @@ hr:nth-of-type(14) {
   display: flex;
   flex-wrap: wrap;
   justify-content: space-between;
+}
+
+.Plugin-badges > * {
   margin-top: 1em;
 }
 

--- a/index.css
+++ b/index.css
@@ -254,6 +254,11 @@ hr:nth-of-type(14) {
 /**
  * Plugin.
  */
+.Plugin-list {
+  max-height: 70vh;
+  overflow: scroll;
+}
+
 .Plugin {
   position: relative;
   padding: 1.5em;

--- a/index.html
+++ b/index.html
@@ -45,5 +45,13 @@
 
   <script type="text/javascript" src="/build.js"></script>
   <script type="text/javascript">require('metalsmith.io');</script>
+  <script src="https://cdn.jsdelivr.net/npm/blazy@1.8.2/blazy.min.js"></script>
+  <script>
+    (function() {
+      var bLazy = new Blazy({
+        validateDelay: 300
+      });
+    })();
+  </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -45,13 +45,5 @@
 
   <script type="text/javascript" src="/build.js"></script>
   <script type="text/javascript">require('metalsmith.io');</script>
-  <script src="https://cdn.jsdelivr.net/npm/blazy@1.8.2/blazy.min.js"></script>
-  <script>
-    (function() {
-      var bLazy = new Blazy({
-        validateDelay: 300
-      });
-    })();
-  </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <meta charset="utf-8">
-  <meta http-equiv="x-ua-compatible" content="ie=edge">  
+  <meta http-equiv="x-ua-compatible" content="ie=edge">
   <title>{{title}}</title>
   <meta name="description" content="{{description}}" />
   <meta name="twitter:card" content="summary_large_image" />

--- a/index.js
+++ b/index.js
@@ -1,6 +1,12 @@
 'use strict';
 /* eslint-env browser */
 
+const Blazy = require('metalsmith.io/node_modules/blazy/blazy.min.js');
+
+const bLazy = new Blazy({
+  validateDelay: 300
+});
+
 const input = document.querySelector('.Plugin-filter-input');
 const plugins = [];
 
@@ -22,6 +28,8 @@ const filter = () => {
       el.style.display = 'none';
     }
   });
+
+  bLazy.revalidate();
 };
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -167,6 +167,11 @@
       "resolved": "https://registry.npmjs.org/batch/-/batch-0.5.3.tgz",
       "integrity": "sha1-PzQU84AyF0O/wQQvmoP/HVgk1GQ="
     },
+    "blazy": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/blazy/-/blazy-1.8.2.tgz",
+      "integrity": "sha1-UN/WOLqvkAPv1us6g2rKVBhKtto="
+    },
     "bluebird": {
       "version": "3.5.1",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "node": "^6.6.0"
   },
   "dependencies": {
+    "blazy": "^1.8.2",
     "component": "^0.19.9",
     "component-builder": "~0.11.2",
     "grunt": "^1.0.1",

--- a/src/index.md
+++ b/src/index.md
@@ -534,11 +534,11 @@ Here's a list of plugins that are provided by the awesome Metalsmith community. 
           alt="GitHub stars"
         />
       </a>
-      <a href="{{ plugin.repository }}">
+      <a href="{{ plugin.bithoundUrl }}">
         <img
           class="b-lazy"
           src="{{placeholderBadgeUrl}}"
-          data-src="{{ plugin.githubIssues }}"
+          data-src="{{ plugin.bithoundScore }}"
           alt="GitHub issues"
         />
       </a>
@@ -546,7 +546,7 @@ Here's a list of plugins that are provided by the awesome Metalsmith community. 
         <img
           class="b-lazy"
           src="{{placeholderBadgeUrl}}"
-          data-src="{{ plugin.bithoundStatus }}"
+          data-src="{{ plugin.bithoundDependencies }}"
           alt="GitHub issues"
         />
       </a>

--- a/src/index.md
+++ b/src/index.md
@@ -509,6 +509,48 @@ Here's a list of plugins that are provided by the awesome Metalsmith community. 
       <i class="Plugin-arrow ss-right"></i>
       <p class="Plugin-description">{{ plugin.description }}</p>
     </a>
+    <div class="Plugin-badges">
+      <a href="{{ plugin.npmUrl }}">
+        <img
+          class="b-lazy"
+          src="{{placeholderBadgeUrl}}"
+          data-src="{{ plugin.npmVersion }}"
+          alt="npm version"
+        />
+      </a>
+      <a href="{{ plugin.npmUrl }}">
+        <img
+          class="b-lazy"
+          src="{{placeholderBadgeUrl}}"
+          data-src="{{ plugin.npmDownloads }}"
+          alt="npm downloads per year"
+        />
+      </a>
+      <a href="{{ plugin.repository }}">
+        <img
+          class="b-lazy"
+          src="{{placeholderBadgeUrl}}"
+          data-src="{{ plugin.githubStars }}"
+          alt="GitHub stars"
+        />
+      </a>
+      <a href="{{ plugin.repository }}">
+        <img
+          class="b-lazy"
+          src="{{placeholderBadgeUrl}}"
+          data-src="{{ plugin.githubIssues }}"
+          alt="GitHub issues"
+        />
+      </a>
+      <a href="{{ plugin.bithoundUrl }}">
+        <img
+          class="b-lazy"
+          src="{{placeholderBadgeUrl}}"
+          data-src="{{ plugin.bithoundStatus }}"
+          alt="GitHub issues"
+        />
+      </a>
+    </div>
   </li>
 {% endfor %}
 </ul>

--- a/src/index.md
+++ b/src/index.md
@@ -539,7 +539,7 @@ Here's a list of plugins that are provided by the awesome Metalsmith community. 
           class="b-lazy"
           src="{{placeholderBadgeUrl}}"
           data-src="{{ plugin.bithoundScore }}"
-          alt="GitHub issues"
+          alt="bitHound score"
         />
       </a>
       <a href="{{ plugin.bithoundUrl }}">
@@ -547,7 +547,7 @@ Here's a list of plugins that are provided by the awesome Metalsmith community. 
           class="b-lazy"
           src="{{placeholderBadgeUrl}}"
           data-src="{{ plugin.bithoundDependencies }}"
-          alt="GitHub issues"
+          alt="bitHound dependencies"
         />
       </a>
     </div>

--- a/src/plugins.json
+++ b/src/plugins.json
@@ -141,6 +141,7 @@
     "name": "Check All Links",
     "icon": "link",
     "repository": "https://github.com/gchallen/code.metalsmith-linkcheck",
+    "npm": "metalsmith-linkcheck",
     "description": "Check all links, both internal and external, in anchors, images, and external page resources."
   },
   {
@@ -219,6 +220,7 @@
     "name": "Creation and Update Timestamps",
     "icon": "clock",
     "repository": "https://github.com/gchallen/code.metalsmith-updated",
+    "npm": "metalsmith-updated",
     "description": "Add creation and updated timestamps"
   },
   {
@@ -502,6 +504,7 @@
     "name": "HTML5 Format Checker",
     "icon": "files",
     "repository": "https://github.com/gchallen/code.metalsmith-formatcheck",
+    "npm": "metalsmith-formatcheck",
     "description": "Use html-validator to validate your HTML."
   },
   {
@@ -1097,6 +1100,7 @@
     "name": "Rework",
     "icon": "files",
     "repository": "https://github.com/dennisschaaf/metallsmith-rework",
+    "npm": "metalsmith-rework",
     "description": "Use rework CSS processor to rework your files."
   },
   {
@@ -1199,6 +1203,7 @@
     "name": "Spell Checking",
     "icon": "compose",
     "repository": "https://github.com/gchallen/code.metalsmith-spellcheck",
+    "npm": "metalsmith-spellcheck",
     "description": "Spell check your site."
   },
   {


### PR DESCRIPTION
The list of plugins is very long and it is getting hard to judge which ones are relevant and in a good shape. This update tries to help here by adding badges which give several informations about every plugin:

* npm version
* npm downloads/year
* github stars
* ~github issues~ (not really useful)
* bithound score (example: https://www.bithound.io/github/chkal/metalsmith-asciidoctor)
* bithound dependencies


It uses lazyload to avoid spamming shields.io and to work around the 200 badges / 5 minutes limitation. Ofc a custom implementation calling these api's once per day would be better but this is much extra efford and till this is done, I think my solution is fine :)

## Preview:
<img width="638" alt="screen shot 2018-01-21 at 15 14 02" src="https://user-images.githubusercontent.com/1737026/35195059-0abd065e-febe-11e7-9e55-cbc565475a0a.png">

## Problems:
* ~If you scroll to much, shields.io will block your IP for a while~ became way better by removing github issues
* ~Lazyloading seems not to be triggered when filtering the plugins 😢 (Should be easy to fix)~ done