### PR TITLE
remove metalsmith-pooleapp

### DIFF
--- a/src/plugins.json
+++ b/src/plugins.json
@@ -980,12 +980,6 @@
     "description": "Simple mirror translations for blog-like entries."
   },
   {
-    "name": "PooleApp",
-    "icon": "write",
-    "repository": "https://github.com/dpobel/metalsmith-pooleapp",
-    "description": "A Metalsmith plugin to retrieve data stored in PooleApp.com."
-  },
-  {
     "name": "PostCSS",
     "icon": "files",
     "repository": "https://github.com/arccoza/metalsmith-with-postcss",

--- a/src/plugins.json
+++ b/src/plugins.json
@@ -1268,12 +1268,6 @@
     "description": "Add timestamp comment to html files"
   },
   {
-    "name": "Title",
-    "icon": "lightbulb",
-    "repository": "https://github.com/OzzyCzech/metalsmith-title",
-    "description": "Automatically generate a page title from first heading in each file."
-  },
-  {
     "name": "Templates",
     "icon": "gridlines",
     "repository": "https://github.com/segmentio/metalsmith-templates",


### PR DESCRIPTION
http://pooleapp.com/ shows bathrooms, not a static site data storage system. I guess the plugin is dead due to service offline.

Let's remove it