### PR TITLE
Add metalsmith-perma to plugins list

### DIFF
--- a/src/plugins.json
+++ b/src/plugins.json
@@ -969,7 +969,12 @@
     "repository": "https://github.com/hellatan/metalsmith-page-titles",
     "description": "Add a global site title to every `<title>` tag."
   },
-
+  {
+    "name": "Perma",
+    "icon": "link",
+    "repository": "https://github.com/scurker/metalsmith-perma",
+    "description": "An alternative to metalsmith-permalinks allowing for custom permalinks and overrides."
+  },
   {
     "name": "Permalinks",
     "icon": "link",


### PR DESCRIPTION
`metalsmith-permalinks` had some outstanding issues, so I created an alternative plugin as a workaround + some additional features.

closes scurker/metalsmith-perma#1