### PR TITLE
Change box sizing to a better default

### DIFF
--- a/lib/css/base/tags.css
+++ b/lib/css/base/tags.css
@@ -3,9 +3,16 @@
  */
 
 html {
+  box-sizing: border-box;
   font: 400 16px/1.6 var(--font-body);
   color: var(--color-dark-gray);
   background: url('/img/ground.jpg') var(--color-light-gray);
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: inherit;
 }
 
 body {

--- a/lib/css/components/example-list.css
+++ b/lib/css/components/example-list.css
@@ -3,7 +3,6 @@
 @media (--lg-viewport) {
   .ExampleList {
     overflow: hidden;
-    margin: 0 -4em;
     column-count: 2;
     column-gap: 1px;
     break-inside: avoid;

--- a/lib/css/components/example.css
+++ b/lib/css/components/example.css
@@ -11,7 +11,7 @@
   font-size: 1.5em;
   margin-top: 0;
   margin-bottom: 0.4em;
-  text-align: center;
+  text-align: left;
 }
 
 .Example-steps {
@@ -22,7 +22,7 @@
 
 @media (--lg-viewport) {
   .Example {
-    padding: 1.5em 2em;
+    padding: 1em 0.5em;
     margin-top: 0;
   }
 


### PR DESCRIPTION
Set box-sizing to a saner default (see [here](https://www.paulirish.com/2012/box-sizing-border-box-ftw/)). To fix this messing up the example list I've changed that slightly. This is in preparation for improving the readability on mobile, which will involve adding a couple more breakpoints, and maybe a wider content width, at which point we'll also be able to address the example list again (i.e. make it look a bit better again).