### PR TITLE
Add metalsmith-projects to plugins listing

### DIFF
--- a/lib/data/plugins.json
+++ b/lib/data/plugins.json
@@ -1048,6 +1048,13 @@
     "description": "Prompt the user for series of answers in the command line and add them to the global metadata."
   },
   {
+    "name": "Projects",
+    "icon": "layergroup",
+    "repository": "https://github.com/AshleyWright/metalsmith-projects",
+    "npm": "metalsmith-projects",
+    "description": "Adds metadata for projects (think portfolio content) from GitHub or filesystem (through collections) that can be looped over for creating a portfolio of work."
+  },
+  {
     "name": "Propdown",
     "icon": "compose",
     "repository": "https://github.com/almirfilho/metalsmith-propdown",

--- a/lib/data/plugins.json
+++ b/lib/data/plugins.json
@@ -1042,17 +1042,17 @@
     "description": "Create static sites with data stored at Prismic.io"
   },
   {
-    "name": "Prompt",
-    "icon": "chat",
-    "repository": "https://github.com/segmentio/metalsmith-prompt",
-    "description": "Prompt the user for series of answers in the command line and add them to the global metadata."
-  },
-  {
     "name": "Projects",
     "icon": "layergroup",
     "repository": "https://github.com/AshleyWright/metalsmith-projects",
     "npm": "metalsmith-projects",
     "description": "Adds metadata for projects (think portfolio content) from GitHub or filesystem (through collections) that can be looped over for creating a portfolio of work."
+  },
+  {
+    "name": "Prompt",
+    "icon": "chat",
+    "repository": "https://github.com/segmentio/metalsmith-prompt",
+    "description": "Prompt the user for series of answers in the command line and add them to the global metadata."
   },
   {
     "name": "Propdown",


### PR DESCRIPTION
metalsmith-projects adds metadata concerning users own github repos and explicitly named repos to the `_metadata` object or otherwise can source this data from file metadata of a named collection (using metalsmith-collections).