### PR TITLE
Add `metalsmith-frontmatter-file-loader` and `metalsmith-frontmatter-renderer` to plugins list

### DIFF
--- a/lib/data/plugins.json
+++ b/lib/data/plugins.json
@@ -417,6 +417,12 @@
     "description": "Iterate through the properties of a frontmatter object and for each property replace the value with the string contents of a utf-8 encoded file resolved using the original value as a file path."
   },
   {
+    "name": "Frontmatter Renderer",
+    "icon": "file",
+    "repository": "https://github.com/djfwilkinson/metalsmith-frontmatter-renderer",
+    "description": "Iterate through the properties of a frontmatter object and for each property render the value using a jstransformer and replace it."
+  },
+  {
     "name": "Project images",
     "icon": "image",
     "repository": "https://github.com/hoetmaaiers/metalsmith-project-images",

--- a/lib/data/plugins.json
+++ b/lib/data/plugins.json
@@ -411,6 +411,12 @@
     "description": "Flatten a directory hierarchy."
   },
   {
+    "name": "Frontmatter File Loader",
+    "icon": "files",
+    "repository": "https://github.com/djfwilkinson/metalsmith-frontmatter-file-loader",
+    "description": "Iterate through the properties of a frontmatter object and for each property replace the value with the string contents of a utf-8 encoded file resolved using the original value as a file path."
+  },
+  {
     "name": "Project images",
     "icon": "image",
     "repository": "https://github.com/hoetmaaiers/metalsmith-project-images",


### PR DESCRIPTION
[metalsmith-frontmatter-file-loader](https://github.com/djfwilkinson/metalsmith-frontmatter-file-loader)
This will load files from paths in a frontmatter object and replace the values with the contents of the file.

[metalsmith-frontmatter-renderer](https://github.com/djfwilkinson/metalsmith-frontmatter-renderer)
This uses jstransformers to render strings that have been added to frontmatter. It uses the same 'object properties' style as the file loader.

Between the two of them it allows you to have small content blocks in separate files and have their values loaded in to frontmatter. This makes it easier to separate markdown content files from nunjucks templates for example.