### PR TITLE
Plugin: metalsmith-html-sri

### DIFF
--- a/lib/data/plugins.json
+++ b/lib/data/plugins.json
@@ -595,7 +595,7 @@
   },
   {
     "name": "HTML Subresource Integrity",
-    "icon": "index",
+    "icon": "lock",
     "repository": "https://github.com/emmercm/metalsmith-html-sri",
     "description": "Add subresource integrity attributes to HTML.",
     "npm": "metalsmith-html-sri"

--- a/lib/data/plugins.json
+++ b/lib/data/plugins.json
@@ -597,8 +597,7 @@
     "name": "HTML Subresource Integrity",
     "icon": "lock",
     "repository": "https://github.com/emmercm/metalsmith-html-sri",
-    "description": "Add subresource integrity attributes to HTML.",
-    "npm": "metalsmith-html-sri"
+    "description": "Add subresource integrity attributes to HTML."
   },
   {
     "name": "HTML Tidy",
@@ -1390,7 +1389,6 @@
     "icon": "files",
     "repository": "https://github.com/moshen/metalsmith-subresource-integrity",
     "description": "Generate integrity hashes for site resources.",
-    "npm": "metalsmith-subresource-integrity",
     "status": "unmaintained"
   },
   {

--- a/lib/data/plugins.json
+++ b/lib/data/plugins.json
@@ -594,6 +594,13 @@
     "description": "Minify your HTML files."
   },
   {
+    "name": "HTML Subresource Integrity",
+    "icon": "index",
+    "repository": "https://github.com/emmercm/metalsmith-html-sri",
+    "description": "Add subresource integrity attributes to HTML.",
+    "npm": "metalsmith-html-sri"
+  },
+  {
     "name": "HTML Tidy",
     "icon": "dishwasher",
     "repository": "https://github.com/hoosteeno/metalsmith-html-tidy",
@@ -1383,6 +1390,7 @@
     "icon": "files",
     "repository": "https://github.com/moshen/metalsmith-subresource-integrity",
     "description": "Generate integrity hashes for site resources.",
+    "npm": "metalsmith-subresource-integrity",
     "status": "unmaintained"
   },
   {


### PR DESCRIPTION
What's the protocol for removing unmaintained packages in favor of maintained packages? We could consider removing `metalsmith-subresource-integrity` altogether.