### PR TITLE
Plugin: metalsmith-html-glob

### DIFF
--- a/lib/data/plugins.json
+++ b/lib/data/plugins.json
@@ -591,8 +591,7 @@
     "name": "HTML Glob",
     "icon": "link",
     "repository": "https://github.com/emmercm/metalsmith-html-glob",
-    "description": "Apply glob patterns within HTML.",
-    "npm": "metalsmith-html-glob"
+    "description": "Apply glob patterns within HTML."
   },
   {
     "name": "HTML Minifier",
@@ -820,7 +819,6 @@
     "icon": "tag",
     "repository": "https://github.com/connected-world-services/metalsmith-link-globs",
     "description": "Instead of manually adding links to files, repeat your script, link, img and a tags by using globs.",
-    "npm": "metalsmith-link-globs",
     "status": "unmaintained"
   },
   {

--- a/lib/data/plugins.json
+++ b/lib/data/plugins.json
@@ -589,7 +589,7 @@
   },
   {
     "name": "HTML Glob",
-    "icon": "index",
+    "icon": "link",
     "repository": "https://github.com/emmercm/metalsmith-html-glob",
     "description": "Apply glob patterns within HTML.",
     "npm": "metalsmith-html-glob"

--- a/lib/data/plugins.json
+++ b/lib/data/plugins.json
@@ -588,6 +588,13 @@
     "description": "Use html-validator to validate your HTML."
   },
   {
+    "name": "HTML Glob",
+    "icon": "index",
+    "repository": "https://github.com/emmercm/metalsmith-html-glob",
+    "description": "Apply glob patterns within HTML.",
+    "npm": "metalsmith-html-glob"
+  },
+  {
     "name": "HTML Minifier",
     "icon": "shredder",
     "repository": "https://github.com/whymarrh/metalsmith-html-minifier",
@@ -813,6 +820,7 @@
     "icon": "tag",
     "repository": "https://github.com/connected-world-services/metalsmith-link-globs",
     "description": "Instead of manually adding links to files, repeat your script, link, img and a tags by using globs.",
+    "npm": "metalsmith-link-globs",
     "status": "unmaintained"
   },
   {


### PR DESCRIPTION
What's the protocol for removing unmaintained packages in favor of maintained packages? We could consider removing `metalsmith-link-globs` altogether.