### PR TITLE
Plugin: metalsmith-link-checker

### DIFF
--- a/lib/data/plugins.json
+++ b/lib/data/plugins.json
@@ -809,6 +809,13 @@
     "status": "unmaintained"
   },
   {
+    "name": "Link Checker",
+    "icon": "unlink",
+    "repository": "https://github.com/emmercm/metalsmith-link-checker",
+    "description": "Check for local and remote broken links.",
+    "npm": "metalsmith-link-checker"
+  },
+  {
     "name": "Link Globs",
     "icon": "tag",
     "repository": "https://github.com/connected-world-services/metalsmith-link-globs",


### PR DESCRIPTION
This somewhat duplicates both `metalsmith-broken-link-checker` and `metalsmith-linkcheck` which haven't had updates in years.