### PR TITLE
Plugin: metalsmith-html-relative

### DIFF
--- a/lib/data/plugins.json
+++ b/lib/data/plugins.json
@@ -606,6 +606,12 @@
     "description": "Minify your HTML files."
   },
   {
+    "name": "HTML Relative",
+    "icon": "link",
+    "repository": "https://github.com/emmercm/metalsmith-html-relative",
+    "description": "Convert to relative paths within HTML."
+  },
+  {
     "name": "HTML Subresource Integrity",
     "icon": "lock",
     "repository": "https://github.com/emmercm/metalsmith-html-sri",


### PR DESCRIPTION
This kind of does what `metalsmith-relative-links` and `metalsmith-rootpath` does, except it manipulates HTML files rather than adding metadata.