### PR TITLE
Plugin: metalsmith-reading-time

### DIFF
--- a/lib/data/plugins.json
+++ b/lib/data/plugins.json
@@ -651,6 +651,12 @@
     "description": "Run plugins in the build sequence conditionally."
   },
   {
+    "name": "Reading Time",
+    "icon": "view",
+    "repository": "https://github.com/emmercm/metalsmith-reading-time",
+    "description": "Estimate pages' reading times."
+  },
+  {
     "name": "Remove",
     "icon": "ban",
     "repository": "https://github.com/metalsmith/remove",


### PR DESCRIPTION
It's similar to `metalsmith-word-count`, except it doesn't calculate word count.