### PR TITLE
Plugins: metalsmith-css-unused

### DIFF
--- a/lib/data/plugins.json
+++ b/lib/data/plugins.json
@@ -247,6 +247,12 @@
     "description": "Add creation and updated timestamps"
   },
   {
+    "name": "CSS Unused",
+    "icon": "scaledown",
+    "repository": "https://github.com/emmercm/metalsmith-css-unused",
+    "description": "Remove unused CSS rules."
+  },
+  {
      "name": "Data Loader",
      "icon": "tag",
      "repository": "https://github.com/tests-always-included/metalsmith-data-loader",


### PR DESCRIPTION
Duplicates:

- `metalsmith-clean-css` (unmaintained)
- `metalsmith-purifycss` (unmaintained)
- `metalsmith-uncss` (unmaintained)

And it's similar to `metalsmith-css-packer` but isn't quite the same.