### PR TITLE
Plugin: metalsmith-include-files

### DIFF
--- a/lib/data/plugins.json
+++ b/lib/data/plugins.json
@@ -697,6 +697,12 @@
     "status": "unmaintained"
   },
   {
+    "name": "Include Files",
+    "icon": "downloadfolder",
+    "repository": "https://github.com/emmercm/metalsmith-include-files",
+    "description": "Include external files in your build."
+  },
+  {
     "name": "Inject Metadata",
     "icon": "pen",
     "repository": "https://github.com/davidtimmons/metalsmith-inject-metadata",


### PR DESCRIPTION
It's basically a batch version of the unmaintained `metalsmith-assets`.

And it maybe duplicates `metalsmith-include-content`, it's hard to tell with the sparse readme.