### PR TITLE
Added metalsmith-groff

### DIFF
--- a/lib/data/plugins.json
+++ b/lib/data/plugins.json
@@ -537,6 +537,13 @@
     "status": "unmaintained"
   },
   {
+    "name": "groff",
+    "icon": "compose",
+    "repository": "https://apps.ti-nuage.fr/gitea/david/metalsmith-groff.git",
+    "description": "Call the groff document formatting system on input files",
+    "npm": "metalsmith-groff"
+  },
+  {
     "name": "gulp-metalsmith",
     "icon": "layergroup",
     "repository": "https://github.com/jelz/gulp-metalsmith",


### PR DESCRIPTION
Hello.

I propose a new plugin to call the groff document formatting system on input file. Groff is the GNU version of the [TN]roff family. It is used for man pages formatting, but comes with a set of classical macro packages to generate memorandums, letters or large books, as well as a set of processors to handle tables, pictures, ... It is ligher than TeX.

I hope it can help.