### PR TITLE
Update plugins.json for the Metadata Plugin, adding npm data and adjusting description.

### DIFF
--- a/lib/data/plugins.json
+++ b/lib/data/plugins.json
@@ -963,8 +963,9 @@
   {
     "name": "Metadata",
     "icon": "tag",
-    "repository": "https://github.com/metalsmith/metalsmith-metadata",
-    "description": "Load metadata from JSON or YAML files."
+    "repository": "https://github.com/metalsmith/metadata",
+    "description": "Load metadata from JSON, YAML, or TOML files.",
+    "npm": "@metalsmith/metadata"
   },
   {
     "name": "Metadata Directory",


### PR DESCRIPTION
According to https://github.com/metalsmith/metadata they now use the @metalsmith scope. So adding it to the plugins.json file. 

Noticed when hovering the entry on the website the npm command that shows still uses the old format.

Also they have added TOML as a valid file to load from so updated description as well.

Please make sure I did it right. Never done this before. Based it on other entries so I think it is correct.